### PR TITLE
Fix for wrong identification of M100 as A3

### DIFF
--- a/dji_sdk/src/modules/dji_sdk_node_main.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_main.cpp
@@ -146,7 +146,7 @@ void DJISDKNode::broadcast_callback()
 ****************************If using A3****************************
 ******************************************************************/
 
-    if(version == DJI::onboardSDK::versionA3_31 || DJI::onboardSDK::versionA3_32) {
+    if(version == DJI::onboardSDK::versionA3_31 || version == DJI::onboardSDK::versionA3_32) {
 
     	//update gimbal msg
     	if (msg_flags & A3_HAS_GIMBAL) {


### PR DESCRIPTION
This fixes an IF-expression that always returns true, i.e., the M100 is wrongly identified as A3. This fixes a problem that some topics are not published on the M100 (Issue #57). 