### PR TITLE
Fix deadlock with memory mutex

### DIFF
--- a/dji_sdk_lib/src/DJI_Link.cpp
+++ b/dji_sdk_lib/src/DJI_Link.cpp
@@ -102,6 +102,10 @@ void CoreAPI::appHandler(Header *protocolHeader)
           serialDevice->freeMemory();
         }
       }  
+      else
+      {
+        serialDevice->freeMemory();
+      }
     }
   }
   else


### PR DESCRIPTION
The memory mutex is not unlocked in the appHandler if usage flag != 1.