### PR TITLE
Update DJI_LIB_ROS_Adapter.h

### DIFF
--- a/dji_sdk/include/dji_sdk/DJI_LIB_ROS_Adapter.h
+++ b/dji_sdk/include/dji_sdk/DJI_LIB_ROS_Adapter.h
@@ -115,10 +115,10 @@ class ROSAdapter {
             printf("Baudrate: %u\n", baudrate);
             printf("-----\n");
 
-            m_hd = new HardDriver_Manifold(device, baudrate);
+            HardDriver_Manifold* m_hd = new HardDriver_Manifold(device, baudrate);
             m_hd->init();
 
-            coreAPI = new CoreAPI( (HardDriver*)m_hd );
+            CoreAPI* coreAPI = new CoreAPI( (HardDriver*)m_hd );
             //no log output while running hotpoint mission
             coreAPI->setHotPointData(false);
 


### PR DESCRIPTION
Should we Initialize the m_hd and coreAPI like what I post?
Since with the original post, when I run the "catkin_make" to compile the workspace, there comes up error said "the m_hd is not declared in this scope".
If so, I think other pointer var in this header file should be initialized in this way.