### PR TITLE
Changing compass fields to 16bits int, 8 bits is insufficient to repr…

### DIFF
--- a/dji_sdk/msg/Compass.msg
+++ b/dji_sdk/msg/Compass.msg
@@ -1,5 +1,5 @@
 Header header
 int32 ts
-int8 x
-int8 y
-int8 z
+int16 x
+int16 y
+int16 z


### PR DESCRIPTION
ROS compass messages used 8 bits to represent a 16 bits information, resulting in unusable messages.