### PR TITLE
Add RTK data publishers

### DIFF
--- a/dji_sdk/include/dji_sdk/dji_sdk_node.h
+++ b/dji_sdk/include/dji_sdk/dji_sdk_node.h
@@ -280,6 +280,11 @@ private:
   ros::Publisher gimbal_angle_publisher;
   ros::Publisher displaymode_publisher;
   ros::Publisher rc_publisher;
+  ros::Publisher rtk_position_publisher;
+  ros::Publisher rtk_velocity_publisher;
+  ros::Publisher rtk_yaw_publisher;
+  ros::Publisher rtk_position_info_publisher;
+  ros::Publisher rtk_yaw_info_publisher;
 
   //! constant
   const int WAIT_TIMEOUT           = 10;

--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -387,6 +387,7 @@ DJISDKNode::initDataSubscribeFromFC()
   // 50 Hz package from FC
   Telemetry::TopicName topicList50Hz[] = {
     Telemetry::TOPIC_GPS_FUSED,
+    Telemetry::TOPIC_GPS_DETAILS,
     Telemetry::TOPIC_HEIGHT_FUSION,
     Telemetry::TOPIC_STATUS_FLIGHT,
     Telemetry::TOPIC_STATUS_DISPLAYMODE,

--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -270,6 +270,22 @@ DJISDKNode::initPublisher(ros::NodeHandle& nh)
   gimbal_angle_publisher =
     nh.advertise<geometry_msgs::Vector3Stamped>("dji_sdk/gimbal_angle", 10);
 
+  rtk_position_publisher =
+    nh.advertise<sensor_msgs::NavSatFix>("dji_sdk/rtk_position", 10);
+
+  rtk_velocity_publisher =
+    nh.advertise<geometry_msgs::Vector3Stamped>("dji_sdk/rtk_velocity", 10);
+
+  rtk_yaw_publisher =
+    nh.advertise<std_msgs::Float32>("dji_sdk/rtk_yaw", 10);
+
+  rtk_position_info_publisher =
+      nh.advertise<std_msgs::UInt8>("dji_sdk/rtk_position_info", 10);
+  rtk_yaw_info_publisher =
+      nh.advertise<std_msgs::UInt8>("dji_sdk/rtk_yaw_info", 10);
+
+
+
   if (telemetry_from_fc == USE_BROADCAST)
   {
     ACK::ErrorCode broadcast_set_freq_ack;
@@ -378,7 +394,12 @@ DJISDKNode::initDataSubscribeFromFC()
     Telemetry::TOPIC_GIMBAL_STATUS,
     Telemetry::TOPIC_RC,
     Telemetry::TOPIC_VELOCITY,
-    Telemetry::TOPIC_GPS_CONTROL_LEVEL
+    Telemetry::TOPIC_GPS_CONTROL_LEVEL,
+    Telemetry::TOPIC_RTK_POSITION,             /*!< RTK position @50Hz */
+    Telemetry::TOPIC_RTK_VELOCITY,             /*!< RTK velocity @50Hz */
+    Telemetry::TOPIC_RTK_YAW,                  /*!< RTK yaw @50Hz */
+    Telemetry::TOPIC_RTK_POSITION_INFO,        /*!< RTK status @50Hz */
+    Telemetry::TOPIC_RTK_YAW_INFO             /*!< RTK yaw status @50Hz */
   };
   int nTopic50Hz    = sizeof(topicList50Hz) / sizeof(topicList50Hz[0]);
   if (vehicle->subscribe->initPackageFromTopicList(PACKAGE_ID_50HZ, nTopic50Hz,

--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -426,7 +426,7 @@ DJISDKNode::initDataSubscribeFromFC()
           Telemetry::TOPIC_GPS_TIME,
           Telemetry::TOPIC_GPS_POSITION,
           Telemetry::TOPIC_GPS_VELOCITY,
-          Telemetry::TOPIC_GPS_DETAILS,
+//          Telemetry::TOPIC_GPS_DETAILS,
           Telemetry::TOPIC_BATTERY_INFO
   };
   int nTopic10Hz = sizeof(topicList10Hz) /sizeof(topicList10Hz[0]);

--- a/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
@@ -309,6 +309,55 @@ DJISDKNode::publish50HzData(Vehicle* vehicle, RecvContainer recvFrame,
   msg_gps_ctrl_level.data = gps_ctrl_level;
   p->gps_health_publisher.publish(msg_gps_ctrl_level);
 
+
+  Telemetry::TypeMap<Telemetry::TOPIC_RTK_POSITION>::type rtk_position =
+    vehicle->subscribe->getValue<Telemetry::TOPIC_RTK_POSITION>();
+
+  sensor_msgs::NavSatFix rtk_position_msg;
+  rtk_position_msg.header.frame_id = "/rtk";
+  rtk_position_msg.header.stamp    = msg_time;
+  rtk_position_msg.latitude        = rtk_position.latitude;   //degree
+  rtk_position_msg.longitude       = rtk_position.longitude;  //degree
+  rtk_position_msg.altitude        = rtk_position.HFSL;       //meter
+  p->rtk_position_publisher.publish(rtk_position_msg);
+
+
+  Telemetry::TypeMap<Telemetry::TOPIC_RTK_VELOCITY>::type v_RTK_FC =
+    vehicle->subscribe->getValue<Telemetry::TOPIC_RTK_VELOCITY>();
+  geometry_msgs::Vector3Stamped rtk_velocity_msg;
+  /*!
+   * note: We are now following REP 103 to use ENU for
+   *       short-range Cartesian representations
+   */
+  rtk_velocity_msg.header.frame_id = "ground_ENU";
+  rtk_velocity_msg.header.stamp = msg_time;
+  rtk_velocity_msg.vector.x = v_RTK_FC.y;  //x, y are swapped from NE to EN
+  rtk_velocity_msg.vector.y = v_RTK_FC.x;
+  rtk_velocity_msg.vector.z = v_RTK_FC.z; //z sign is already U
+  p->rtk_velocity_publisher.publish(rtk_velocity_msg);
+
+
+  Telemetry::TypeMap<Telemetry::TOPIC_RTK_YAW>::type rtk_yaw =
+    vehicle->subscribe->getValue<Telemetry::TOPIC_RTK_YAW>();
+  std_msgs::Float32 rtk_yaw_msg;
+  rtk_yaw_msg.data = rtk_yaw;
+  p->rtk_yaw_publisher.publish(rtk_yaw_msg);
+
+
+  Telemetry::TypeMap<Telemetry::TOPIC_RTK_POSITION_INFO>::type rtk_position_info =
+    vehicle->subscribe->getValue<Telemetry::TOPIC_RTK_POSITION_INFO>();
+  std_msgs::UInt8 rtk_position_info_msg;
+  rtk_position_info_msg.data = rtk_position_info;
+  p->rtk_position_info_publisher.publish(rtk_position_info_msg);
+
+
+  Telemetry::TypeMap<Telemetry::TOPIC_RTK_YAW_INFO>::type rtk_yaw_info =
+    vehicle->subscribe->getValue<Telemetry::TOPIC_RTK_YAW_INFO>();
+  std_msgs::UInt8 rtk_yaw_info_msg;
+  rtk_yaw_info_msg.data = rtk_yaw_info;
+  p->rtk_yaw_info_publisher.publish(rtk_yaw_info_msg);
+
+
   Telemetry::TypeMap<Telemetry::TOPIC_GIMBAL_ANGLES>::type gimbal_angle =
     vehicle->subscribe->getValue<Telemetry::TOPIC_GIMBAL_ANGLES>();
 


### PR DESCRIPTION
This commit adds RTK data publishers to Onboard-SDK-ROS 3.3.
New topics:

- dji_sdk/rtk_position (of type sensor_msgs::NavSatFix)
- dji_sdk/rtk_velocity (of type geometry_msgs::Vector3Stamped)
- dji_sdk/rtk_yaw (of type std_msgs::Float32)
- dji_sdk/rtk_position_info (of type std_msgs::UInt8)
- dji_sdk/rtk_yaw_info (of type std_msgs::UInt8)

Tested on M600Pro.