### PR TITLE
Fix for Gimbal speed subscriber

### DIFF
--- a/dji_sdk/src/modules/dji_sdk_node_subscriber.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_subscriber.cpp
@@ -35,6 +35,7 @@ DJISDKNode::gimbalSpeedCtrlCallback(
 
   DJI::OSDK::Gimbal::SpeedData speed_data;
   //! OSDK takes 0.1 deg as unit
+  speed_data.gimbal_control_authority = 1;
   speed_data.roll  = RAD2DEG(msg->vector.x)*10;
   speed_data.pitch = RAD2DEG(msg->vector.y)*10;
   speed_data.yaw   = RAD2DEG(msg->vector.z)*10;


### PR DESCRIPTION
Hey

This is the fix for Gimbal speed callback. The existing ROS Gimbal example which sends the speed commands is not working, but the angle control works well. This fix solved that issue.

Regards
Lentin Joseph