### PR TITLE
Fixed wrong publish rate for RTK data

### DIFF
--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -475,7 +475,7 @@ DJISDKNode::initDataSubscribeFromFC(ros::NodeHandle& nh)
 
   int nTopicRTKSupport    = sizeof(topicRTKSupport)/sizeof(topicRTKSupport[0]);
   if (vehicle->subscribe->initPackageFromTopicList(PACKAGE_ID_5HZ, nTopicRTKSupport,
-                                                   topicRTKSupport, 1, 10))
+                                                   topicRTKSupport, 1, 5))
   {
     ack = vehicle->subscribe->startPackage(PACKAGE_ID_5HZ, WAIT_TIMEOUT);
     if (ack.data == ErrorCode::SubscribeACK::SOURCE_DEVICE_OFFLINE)


### PR DESCRIPTION
On a Matrice 600 Pro, the RTK data is published from the flight controller at 5Hz. Changing this value from "10" to "5" allows proper subscription to RTK data from the flight controller and publishing to the ROS environment. `initPackageFromTopicList()` returns false for RTK data without this change. Untested on other platforms.