### PR TITLE
fix build errors

### DIFF
--- a/dji_sdk/CMakeLists.txt
+++ b/dji_sdk/CMakeLists.txt
@@ -37,7 +37,7 @@ set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-catkin_python_setup()
+# catkin_python_setup()
 
 ################################################
 ## Declare ROS messages, services and actions ##

--- a/dji_sdk_demo/CMakeLists.txt
+++ b/dji_sdk_demo/CMakeLists.txt
@@ -164,6 +164,7 @@ catkin_package(
 # include_directories(include)
 include_directories(
         include
+        ${DJIOSDK_INCLUDE_DIRS}
         ${catkin_INCLUDE_DIRS}
 )
 
@@ -308,9 +309,9 @@ endif()
 
 ## Mark cpp header files for installation
 
-install(DIRECTORY launch
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-        )
+# install(DIRECTORY launch
+#         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+#         )
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 # install(FILES
 #   # myfile1


### PR DESCRIPTION
Some small fixes to remove build errors. These errors are caused by:
-  removed Python files
-  removed launch files
-  missing `${DJIOSDK_INCLUDE_DIRS}` variable in `include_directories`
There are some cmake directives depending on these removed files, causing the build to fail.