### PR TITLE
fix get upwards avoid enable status

### DIFF
--- a/src/dji_osdk_ros/dji_vehicle_node.cpp
+++ b/src/dji_osdk_ros/dji_vehicle_node.cpp
@@ -1748,7 +1748,7 @@ bool VehicleNode::getAvoidEnableStatusCallback(GetAvoidEnable::Request& request,
     return false;
   }
 
-  response.upwards_avoid_enable_status = get_horizon_avoid_enable_status;
+  response.upwards_avoid_enable_status = get_upwards_avoid_enable_status;
 
   response.result = true;
   return true;


### PR DESCRIPTION
This PR fixes the bug when getting the current status of the upwards avoid system.
When you try to call the service `/get_avoid_enable_status` to obtain the current status of the avoidance system you get the following:
```
result: True                                                                                       
horizon_avoid_enable_status: 0                                                        
upwards_avoid_enable_status: 0 
```
And if I enable just the horizon_avoid with `rosservice call /robot119/set_horizon_avoid_enable "enable: true"` and check again the status I get:
```
result: True                                                                                        
horizon_avoid_enable_status: 1                                                                   
upwards_avoid_enable_status: 1
```