### PR TITLE
Update dji_vehicle_node_mission_services.cpp

### DIFF
--- a/src/dji_osdk_ros/modules/dji_vehicle_node_mission_services.cpp
+++ b/src/dji_osdk_ros/modules/dji_vehicle_node_mission_services.cpp
@@ -641,7 +641,8 @@ bool VehicleNode::waypointV2UploadActionCallback(
     return false;
   }
   response.result = ptr_wrapper_->uploadWaypointV2Actions(this->actions, WAIT_TIMEOUT);
-
+  if (response.result) this->actions.clear();
+  
   return response.result;
 }
 


### PR DESCRIPTION
**Changes**: clear the actions vector after uploadWaypointV2Actions was successful

**Reason**: Actions that have been generated by the "generateWaypointV2Action" ROS Service should be flushed after they have been uploaded to the drone.
Otherwise you will upload old actions again, when you generate new ones and upload them via the ROS service.